### PR TITLE
Add a config endpoint on a new api server

### DIFF
--- a/cmd/agent/api/listener.go
+++ b/cmd/agent/api/listener.go
@@ -22,10 +22,6 @@ func getIPCAddressPort() (string, error) {
 }
 
 // getListener returns a listening connection
-func getListener() (net.Listener, error) {
-	address, err := getIPCAddressPort()
-	if err != nil {
-		return nil, err
-	}
+func getListener(address string) (net.Listener, error) {
 	return net.Listen("tcp", address)
 }

--- a/cmd/agent/api/security.go
+++ b/cmd/agent/api/security.go
@@ -17,16 +17,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 )
 
-var (
-	tlsKeyPair  *tls.Certificate
-	tlsCertPool *x509.CertPool
-	tlsAddr     string
-)
-
 // validateToken - validates token for legacy API
 func validateToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := util.Validate(w, r); err != nil {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -46,13 +41,9 @@ func parseToken(token string) (interface{}, error) {
 	return struct{}{}, nil
 }
 
-func buildSelfSignedKeyPair() ([]byte, []byte) {
-
+func buildSelfSignedKeyPair(extraHosts ...string) ([]byte, []byte) {
 	hosts := []string{"127.0.0.1", "localhost", "::1"}
-	ipcAddr, err := getIPCAddressPort()
-	if err == nil {
-		hosts = append(hosts, ipcAddr)
-	}
+	hosts = append(hosts, extraHosts...)
 	_, rootCertPEM, rootKey, err := security.GenerateRootCert(hosts, 2048)
 	if err != nil {
 		return nil, nil
@@ -67,26 +58,21 @@ func buildSelfSignedKeyPair() ([]byte, []byte) {
 	return rootCertPEM, rootKeyPEM
 }
 
-func initializeTLS() error {
-	cert, key := buildSelfSignedKeyPair()
+func initializeTLS(extraHosts ...string) (*tls.Certificate, *x509.CertPool, error) {
+	cert, key := buildSelfSignedKeyPair(extraHosts...)
 	if cert == nil {
-		return errors.New("unable to generate certificate")
+		return nil, nil, errors.New("unable to generate certificate")
 	}
 	pair, err := tls.X509KeyPair(cert, key)
 	if err != nil {
-		return fmt.Errorf("unable to generate TLS key pair: %v", err)
+		return nil, nil, fmt.Errorf("unable to generate TLS key pair: %v", err)
 	}
-	tlsKeyPair = &pair
-	tlsCertPool = x509.NewCertPool()
+
+	tlsCertPool := x509.NewCertPool()
 	ok := tlsCertPool.AppendCertsFromPEM(cert)
 	if !ok {
-		return fmt.Errorf("unable to add new certificate to pool")
+		return nil, nil, fmt.Errorf("unable to add new certificate to pool")
 	}
 
-	tlsAddr, err = getIPCAddressPort()
-	if err != nil {
-		return fmt.Errorf("unable to get IPC address and port: %v", err)
-	}
-
-	return nil
+	return &pair, tlsCertPool, nil
 }

--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -11,28 +11,17 @@ sending commands and receiving infos.
 package api
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	stdLog "log"
 	"net"
 	"net/http"
-	"time"
+	"strconv"
 
 	"github.com/cihub/seelog"
-	gorilla "github.com/gorilla/mux"
-	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/internal/agent"
-	"github.com/DataDog/datadog-agent/cmd/agent/api/internal/check"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
-	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	workloadmetaServer "github.com/DataDog/datadog-agent/comp/core/workloadmeta/server"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
@@ -44,14 +33,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
-	"github.com/DataDog/datadog-agent/pkg/tagger"
-	taggerserver "github.com/DataDog/datadog-agent/pkg/tagger/server"
-	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
-var listener net.Listener
+func startServer(listener net.Listener, srv *http.Server, name string) {
+	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
+	logWriter, _ := config.NewLogWriter(5, seelog.ErrorLvl)
+
+	srv.ErrorLog = stdLog.New(logWriter, fmt.Sprintf("Error from the agent http %s: ", name), 0) // log errors to seelog
+
+	tlsListener := tls.NewListener(listener, srv.TLSConfig)
+
+	go srv.Serve(tlsListener) //nolint:errcheck
+
+	log.Infof("%s started on %s", name, listener.Addr().String())
+}
 
 // StartServer creates the router and starts the HTTP server
 func StartServer(
@@ -65,128 +62,68 @@ func StartServer(
 	senderManager sender.DiagnoseSenderManager,
 	hostMetadata host.Component,
 	invAgent inventoryagent.Component,
-	demux demultiplexer.Component,
 	invHost inventoryhost.Component,
-	secretResolver secrets.Component,
 ) error {
-	err := initializeTLS()
+	apiAddr, err := getIPCAddressPort()
+	if err != nil {
+		return fmt.Errorf("unable to get IPC address and port: %v", err)
+	}
+
+	extraHosts := []string{apiAddr}
+	ipcHost, err := config.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+	apiConfigPort := config.Datadog.GetInt("api_config_port")
+	apiConfigEnabled := apiConfigPort > 0
+	apiConfigHostPort := net.JoinHostPort(ipcHost, strconv.Itoa(apiConfigPort))
+
+	if apiConfigEnabled {
+		extraHosts = append(extraHosts, apiConfigHostPort)
+	}
+
+	tlsKeyPair, tlsCertPool, err := initializeTLS(extraHosts...)
 	if err != nil {
 		return fmt.Errorf("unable to initialize TLS: %v", err)
 	}
 
-	// get the transport we're going to use under HTTP
-	listener, err = getListener()
-	if err != nil {
-		// we use the listener to handle commands for the Agent, there's
-		// no way we can recover from this error
-		return fmt.Errorf("Unable to create the api server: %v", err)
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{*tlsKeyPair},
+		NextProtos:   []string{"h2"},
+		MinVersion:   tls.VersionTLS12,
 	}
 
-	err = util.CreateAndSetAuthToken()
-	if err != nil {
+	if err := util.CreateAndSetAuthToken(); err != nil {
 		return err
 	}
 
-	// gRPC server
-	authInterceptor := grpcutil.AuthInterceptor(parseToken)
-	opts := []grpc.ServerOption{
-		grpc.Creds(credentials.NewClientTLSFromCert(tlsCertPool, tlsAddr)),
-		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authInterceptor)),
-		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(authInterceptor)),
+	if err := startAPIServer(
+		apiAddr, tlsConfig, tlsCertPool,
+		configService, flare, dogstatsdServer,
+		capture, serverDebug, wmeta, logsAgent,
+		senderManager, hostMetadata, invAgent,
+		invHost,
+	); err != nil {
+		return err
 	}
 
-	s := grpc.NewServer(opts...)
-	pb.RegisterAgentServer(s, &server{})
-	pb.RegisterAgentSecureServer(s, &serverSecure{
-		configService: configService,
-		taggerServer:  taggerserver.NewServer(tagger.GetDefaultTagger()),
-		// TODO(components): decide if workloadmetaServer should be componentized itself
-		workloadmetaServer: workloadmetaServer.NewServer(wmeta),
-		dogstatsdServer:    dogstatsdServer,
-		capture:            capture,
-	})
-
-	dcreds := credentials.NewTLS(&tls.Config{
-		ServerName: tlsAddr,
-		RootCAs:    tlsCertPool,
-	})
-	dopts := []grpc.DialOption{grpc.WithTransportCredentials(dcreds)}
-
-	// starting grpc gateway
-	ctx := context.Background()
-	gwmux := runtime.NewServeMux()
-	err = pb.RegisterAgentHandlerFromEndpoint(
-		ctx, gwmux, tlsAddr, dopts)
-	if err != nil {
-		return fmt.Errorf("error registering agent handler from endpoint %s: %v", tlsAddr, err)
+	if apiConfigEnabled {
+		if err := startConfigServer(apiConfigHostPort, tlsConfig); err != nil {
+			StopServer()
+			return err
+		}
 	}
 
-	err = pb.RegisterAgentSecureHandlerFromEndpoint(
-		ctx, gwmux, tlsAddr, dopts)
-	if err != nil {
-		return fmt.Errorf("error registering agent secure handler from endpoint %s: %v", tlsAddr, err)
-	}
-
-	// Setup multiplexer
-	// create the REST HTTP router
-	agentMux := gorilla.NewRouter()
-	checkMux := gorilla.NewRouter()
-	// Validate token for every request
-	agentMux.Use(validateToken)
-	checkMux.Use(validateToken)
-
-	mux := http.NewServeMux()
-	mux.Handle(
-		"/agent/",
-		http.StripPrefix("/agent",
-			agent.SetupHandlers(
-				agentMux,
-				flare,
-				dogstatsdServer,
-				serverDebug,
-				wmeta,
-				logsAgent,
-				senderManager,
-				hostMetadata,
-				invAgent,
-				demux,
-				invHost,
-				secretResolver,
-			)))
-	mux.Handle("/check/", http.StripPrefix("/check", check.SetupHandlers(checkMux)))
-	mux.Handle("/", gwmux)
-
-	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := config.NewLogWriter(5, seelog.ErrorLvl)
-
-	srv := grpcutil.NewMuxedGRPCServer(
-		tlsAddr,
-		&tls.Config{
-			Certificates: []tls.Certificate{*tlsKeyPair},
-			NextProtos:   []string{"h2"},
-			MinVersion:   tls.VersionTLS12,
-		},
-		s,
-		grpcutil.TimeoutHandlerFunc(mux, time.Duration(config.Datadog.GetInt64("server_timeout"))*time.Second),
-	)
-
-	srv.ErrorLog = stdLog.New(logWriter, "Error from the agent http API server: ", 0) // log errors to seelog
-
-	tlsListener := tls.NewListener(listener, srv.TLSConfig)
-
-	go srv.Serve(tlsListener) //nolint:errcheck
 	return nil
 }
 
 // StopServer closes the connection and the server
 // stops listening to new commands.
 func StopServer() {
-	if listener != nil {
-		listener.Close()
+	if apiListener != nil {
+		apiListener.Close()
 	}
-}
-
-// ServerAddress retruns the server address.
-func ServerAddress() *net.TCPAddr {
-	return listener.Addr().(*net.TCPAddr)
+	if apiConfigListener != nil {
+		apiConfigListener.Close()
+	}
 }

--- a/cmd/agent/api/server_api.go
+++ b/cmd/agent/api/server_api.go
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	gorilla "github.com/gorilla/mux"
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/api/internal/agent"
+	"github.com/DataDog/datadog-agent/cmd/agent/api/internal/check"
+	"github.com/DataDog/datadog-agent/comp/core/flare"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	workloadmetaServer "github.com/DataDog/datadog-agent/comp/core/workloadmeta/server"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
+	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
+	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
+	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
+	"github.com/DataDog/datadog-agent/comp/metadata/host"
+	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
+	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	taggerserver "github.com/DataDog/datadog-agent/pkg/tagger/server"
+	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+)
+
+var apiListener net.Listener
+
+func startAPIServer(
+	apiAddr string,
+	tlsConfig *tls.Config,
+	tlsCertPool *x509.CertPool,
+	configService *remoteconfig.Service,
+	flare flare.Component,
+	dogstatsdServer dogstatsdServer.Component,
+	capture replay.Component,
+	serverDebug dogstatsddebug.Component,
+	wmeta workloadmeta.Component,
+	logsAgent optional.Option[logsAgent.Component],
+	senderManager sender.DiagnoseSenderManager,
+	hostMetadata host.Component,
+	invAgent inventoryagent.Component,
+	invHost inventoryhost.Component,
+) (err error) {
+	// get the transport we're going to use under HTTP
+	apiListener, err = getListener(apiAddr)
+	if err != nil {
+		// we use the listener to handle commands for the Agent, there's
+		// no way we can recover from this error
+		return fmt.Errorf("Unable to create the api server: %v", err)
+	}
+
+	// gRPC server
+	authInterceptor := grpcutil.AuthInterceptor(parseToken)
+	opts := []grpc.ServerOption{
+		grpc.Creds(credentials.NewClientTLSFromCert(tlsCertPool, apiAddr)),
+		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authInterceptor)),
+		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(authInterceptor)),
+	}
+
+	s := grpc.NewServer(opts...)
+	pb.RegisterAgentServer(s, &server{})
+	pb.RegisterAgentSecureServer(s, &serverSecure{
+		configService: configService,
+		taggerServer:  taggerserver.NewServer(tagger.GetDefaultTagger()),
+		// TODO(components): decide if workloadmetaServer should be componentized itself
+		workloadmetaServer: workloadmetaServer.NewServer(wmeta),
+		dogstatsdServer:    dogstatsdServer,
+		capture:            capture,
+	})
+
+	dcreds := credentials.NewTLS(&tls.Config{
+		ServerName: apiAddr,
+		RootCAs:    tlsCertPool,
+	})
+	dopts := []grpc.DialOption{grpc.WithTransportCredentials(dcreds)}
+
+	// starting grpc gateway
+	ctx := context.Background()
+	gwmux := runtime.NewServeMux()
+	err = pb.RegisterAgentHandlerFromEndpoint(
+		ctx, gwmux, apiAddr, dopts)
+	if err != nil {
+		return fmt.Errorf("error registering agent handler from endpoint %s: %v", apiAddr, err)
+	}
+
+	err = pb.RegisterAgentSecureHandlerFromEndpoint(
+		ctx, gwmux, apiAddr, dopts)
+	if err != nil {
+		return fmt.Errorf("error registering agent secure handler from endpoint %s: %v", apiAddr, err)
+	}
+
+	// Setup multiplexer
+	// create the REST HTTP router
+	agentMux := gorilla.NewRouter()
+	checkMux := gorilla.NewRouter()
+	// Validate token for every request
+	agentMux.Use(validateToken)
+	checkMux.Use(validateToken)
+
+	apiMux := http.NewServeMux()
+	apiMux.Handle(
+		"/agent/",
+		http.StripPrefix("/agent",
+			agent.SetupHandlers(
+				agentMux,
+				flare,
+				dogstatsdServer,
+				serverDebug,
+				wmeta,
+				logsAgent,
+				senderManager,
+				hostMetadata,
+				invAgent,
+				invHost,
+			)))
+	apiMux.Handle("/check/", http.StripPrefix("/check", check.SetupHandlers(checkMux)))
+	apiMux.Handle("/", gwmux)
+
+	srv := grpcutil.NewMuxedGRPCServer(
+		apiAddr,
+		tlsConfig,
+		s,
+		grpcutil.TimeoutHandlerFunc(apiMux, time.Duration(config.Datadog.GetInt64("server_timeout"))*time.Second),
+	)
+
+	startServer(apiListener, srv, "API server")
+
+	return nil
+}
+
+// ServerAddress returns the server address.
+func ServerAddress() *net.TCPAddr {
+	return apiListener.Addr().(*net.TCPAddr)
+}

--- a/cmd/agent/api/server_config.go
+++ b/cmd/agent/api/server_config.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	gorilla "github.com/gorilla/mux"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var apiConfigListener net.Listener
+
+func startConfigServer(apiConfigHostPort string, tlsConfig *tls.Config) (err error) {
+	apiConfigListener, err = getListener(apiConfigHostPort)
+	if err != nil {
+		return err
+	}
+
+	configEndpointHandler := func(w http.ResponseWriter, r *http.Request) {
+		vars := gorilla.Vars(r)
+
+		body, err := getConfigMarshalled(vars["path"])
+		if err != nil {
+			body, _ := json.Marshal(map[string]string{"error": err.Error()})
+			http.Error(w, string(body), http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write(body)
+	}
+
+	configEndpointMux := gorilla.NewRouter()
+	configEndpointMux.HandleFunc("/", configEndpointHandler).Methods("GET")
+	configEndpointMux.HandleFunc("/.", configEndpointHandler).Methods("GET")
+	configEndpointMux.HandleFunc("/{path}", configEndpointHandler).Methods("GET")
+	configEndpointMux.Use(validateToken)
+
+	apiConfigMux := http.NewServeMux()
+	apiConfigMux.Handle(
+		"/config/",
+		http.StripPrefix("/config", configEndpointMux))
+
+	apiConfigServer := &http.Server{
+		Addr:      apiConfigHostPort,
+		Handler:   http.TimeoutHandler(apiConfigMux, time.Duration(config.Datadog.GetInt64("server_timeout"))*time.Second, "timeout"),
+		TLSConfig: tlsConfig,
+	}
+
+	startServer(apiConfigListener, apiConfigServer, "Config API server")
+
+	return nil
+}
+
+func getConfigMarshalled(path string) ([]byte, error) {
+	if path == "." {
+		path = ""
+	}
+
+	var data interface{}
+	if path == "" {
+		data = config.Datadog.AllSettings()
+	} else {
+		data = config.Datadog.Get(path)
+	}
+
+	if data == nil {
+		return nil, fmt.Errorf("no runtime setting found for %s", path)
+	}
+
+	return json.Marshal(map[string]interface{}{
+		"request": path,
+		"value":   data,
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -247,6 +247,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("syslog_tls_verify", true)
 	config.BindEnvAndSetDefault("ipc_address", "localhost")
 	config.BindEnvAndSetDefault("cmd_port", 5001)
+	config.BindEnvAndSetDefault("api_config_port", 5004)
 	config.BindEnvAndSetDefault("default_integration_http_timeout", 9)
 	config.BindEnvAndSetDefault("integration_tracing", false)
 	config.BindEnvAndSetDefault("integration_tracing_exhaustive", false)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a config endpoint on a new api server.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Eventually allow synchronizing config values (which can be dynamic with RC) across agent processes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The new server is on a different port than the usual `ipc_port`, which means we have to create an entirely new http server.
The security of the server is the same as the one of the usual API server.

I used the same cert for both servers, but we can easily refactor it to use separate ones, it might be better if we want both servers to be completely separate.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Enable the endpoint by setting a non zero value to `agent_ipc_port` (eg. 5004).
Check that the original API server still works, and that the new api server works properly for various configs.
The following command queries the endpoint from CLI:
```
curl -qs -H "authorization: Bearer $(cat <auth_token path>)" -k https://localhost:5004/config/api_key
``` 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a new API server with gRPC and HTTP endpoints, enhancing the modularity of the codebase.
- Improvement: Updated `getListener` function to accept an address argument directly, increasing flexibility and reducing dependencies.
- New Feature: Added a `/config/` endpoint to the API server that returns JSON-encoded configuration data.
- Improvement: Enhanced token validation in `validateToken` function to return a 403 Forbidden response on failure.
- Improvement: Modified `buildSelfSignedKeyPair` and `initializeTLS` functions to accept additional hosts, improving flexibility in TLS certificate generation.
- New Feature: Added a new configuration option `api_config_port` to specify the port number for the API server's config endpoint.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->